### PR TITLE
Add renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommitsDisabled"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "separateMajorMinor": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["/postgres/"],
+      "matchUpdateTypes": ["major", "patch"],
+      "enabled": false
+    },
+    {
+      "matchFileNames": [".pre-commit-config.yaml"],
+      "enabled": true,
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["* 0-6 1 * *"],
+      "automergeSchedule": ["* 0-6 1 * *"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/defaults/main.yml$/"
+      ],
+      "matchStrings": [
+        "(?<name>postgres_container_image_v\\d+):\\s*[\"']?{{\\s*[^}]+\\s*}}\\s*postgres:(?<currentValue>[^}]+)\\s*\\{\\{\\s*[^}]+\\s*\\}\\}"
+      ],
+      "depNameTemplate": "postgres",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver-coerced"
+    }
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+---
+default_install_hook_types: [pre-push]
+
+exclude: 'LICENSES/'
+
+# See: https://pre-commit.com/hooks.html
+repos:
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 41.21.3
+    hooks:
+      - id: renovate-config-validator


### PR DESCRIPTION
Reuse https://github.com/mother-of-all-self-hosting/ansible-role-mariadb/blob/7ce86572d752d448b5df710f8c386a99c70ef301/.github/renovate.json

This commit adds renovate.json so that minor update is detected, ignoring major ones. As there is not a patch level update on Postgres, "semver-coerced" is adopted to versioningTemplate instead of "semver".